### PR TITLE
Rename package from singular "sabhero-article" to plural "sabhero-articles" across all namespaces, classes, configs, routes, views, and documentation to ensure consistent naming and branding. #major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,54 @@
 # Changelog
 
-All notable changes to `laravel-sabhero-article` will be documented in this file.
+All notable changes to `laravel-sabhero-articles` will be documented in this file.
 
 ## v0.0.18 - 2025-08-28
 
 ### What's Changed
 
-* Integrate ralphjsmit glide by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-article/pull/28
+* Integrate ralphjsmit glide by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-articles/pull/28
 
-**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-article/compare/v0.0.17...v0.0.18
+**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-articles/compare/v0.0.17...v0.0.18
 
 ## v0.0.17 - 2025-08-28
 
 ### What's Changed
 
-* Improve article views layout and styling, enhance breadcrumb link truncation, adjust app layout padding and margins, and add a collapsible, state-persistent toggle button to the Table of Contents for better usability. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-article/pull/27
+* Improve article views layout and styling, enhance breadcrumb link truncation, adjust app layout padding and margins, and add a collapsible, state-persistent toggle button to the Table of Contents for better usability. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-articles/pull/27
 
-**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-article/compare/v0.0.16...v0.0.17
+**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-articles/compare/v0.0.16...v0.0.17
 
 ## v0.0.16 - 2025-08-07
 
 ### What's Changed
 
-* Add pages table migration and seeder publishing; update README with seeder publishing and running instructions; remove unused package dependency. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-article/pull/26
+* Add pages table migration and seeder publishing; update README with seeder publishing and running instructions; remove unused package dependency. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-articles/pull/26
 
-**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-article/compare/v0.0.15...v0.0.16
+**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-articles/compare/v0.0.15...v0.0.16
 
 ## v0.0.15 - 2025-07-31
 
 ### What's Changed
 
-* Add a new seeder for the Page model to populate initial page data and update the media conversion name for feature images to ensure consistency in the media library. This change enhances the database seeding process and improves the handling of feature images associated with pages. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-article/pull/25
+* Add a new seeder for the Page model to populate initial page data and update the media conversion name for feature images to ensure consistency in the media library. This change enhances the database seeding process and improves the handling of feature images associated with pages. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-articles/pull/25
 
-**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-article/compare/v0.0.14...v0.0.15
+**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-articles/compare/v0.0.14...v0.0.15
 
 ## v0.0.14 - 2025-07-31
 
 ### What's Changed
 
-* Add 'feature_image' to the fillable attributes in the Page model and update the unique validation to use the class name dynamically while ensuring the slug is formatted to lowercase. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-article/pull/24
+* Add 'feature_image' to the fillable attributes in the Page model and update the unique validation to use the class name dynamically while ensuring the slug is formatted to lowercase. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-articles/pull/24
 
-**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-article/compare/v0.0.13...v0.0.14
+**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-articles/compare/v0.0.13...v0.0.14
 
 ## v0.0.13 - 2025-07-27
 
 ### What's Changed
 
-* Update article config prefixes to plural, add 'Route' labels to slug fields for clarity, enhance Table of Contents styling for better dark mode support, and adjust service provider to register FeedServiceProvider after views are loaded. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-article/pull/23
+* Update article config prefixes to plural, add 'Route' labels to slug fields for clarity, enhance Table of Contents styling for better dark mode support, and adjust service provider to register FeedServiceProvider after views are loaded. by @thejmitchener in https://github.com/fuelviews/laravel-sabhero-articles/pull/23
 
-**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-article/compare/v0.0.12...v0.0.13
+**Full Changelog**: https://github.com/fuelviews/laravel-sabhero-articles/compare/v0.0.12...v0.0.13
 
 ## v0.0.10 - 2025-06-17
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SAB Hero Articles Package
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/fuelviews/laravel-sabhero-article.svg?style=flat-square)](https://packagist.org/packages/fuelviews/laravel-sabhero-article)
-[![Total Downloads](https://img.shields.io/packagist/dt/fuelviews/laravel-sabhero-article.svg?style=flat-square)](https://packagist.org/packages/fuelviews/laravel-sabhero-article)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/fuelviews/laravel-sabhero-articles.svg?style=flat-square)](https://packagist.org/packages/fuelviews/laravel-sabhero-articles)
+[![Total Downloads](https://img.shields.io/packagist/dt/fuelviews/laravel-sabhero-articles.svg?style=flat-square)](https://packagist.org/packages/fuelviews/laravel-sabhero-articles)
 
 A full-featured article management solution for Laravel applications with Filament admin panel integration. This package provides a complete article publishing platform with advanced features and an intuitive admin interface.
 
@@ -36,7 +36,7 @@ php artisan make:filament-user
 ### Install the SAB Hero Articles Package
 
 ```bash
-composer require fuelviews/laravel-sabhero-article
+composer require fuelviews/laravel-sabhero-articles
 ```
 
 ## Configuration
@@ -44,13 +44,13 @@ composer require fuelviews/laravel-sabhero-article
 ### 1. Publish Configuration Files
 
 ```bash
-php artisan vendor:publish --tag="sabhero-article-config"
+php artisan vendor:publish --tag="sabhero-articles-config"
 ```
 
 ### 2. Publish Migrations
 
 ```bash
-php artisan vendor:publish --tag="sabhero-article-migrations"
+php artisan vendor:publish --tag="sabhero-articles-migrations"
 ```
 
 ### 3. Run Migrations
@@ -62,7 +62,7 @@ php artisan migrate
 ### 4. Publish Seeders
 
 ```bash
-php artisan vendor:publish --tag="sabhero-article-seeders"
+php artisan vendor:publish --tag="sabhero-articles-seeders"
 ```
 
 ### 5. Publish Seeders
@@ -83,13 +83,13 @@ php artisan db:seed --class=PageTableSeede
 Add the SAB Hero Articles plugin to your Filament panel provider:
 
 ```php
-use Fuelviews\SabHeroArticle\Facades\SabHeroArticle;
+use Fuelviews\SabHeroArticles\Facades\SabHeroArticles;
 
 public function panel(Panel $panel): Panel
 {
     return $panel
         ->plugins([
-            SabHeroArticle::make()
+            SabHeroArticles::make()
         ]);
 }
 ```
@@ -101,7 +101,7 @@ Your user model needs to be setup to use the `HasArticle` trait and ensure the r
 ```php
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
-use Fuelviews\SabHeroArticle\Traits\HasArticle;
+use Fuelviews\SabHeroArticles\Traits\HasArticle;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -129,7 +129,7 @@ class User extends Authenticatable implements FilamentUser
     
     public function canAccessPanel(Panel $panel): bool
     {
-        $allowedDomains = config('sabhero-article.user.allowed_domains', []);
+        $allowedDomains = config('sabhero-articles.user.allowed_domains', []);
 
         foreach ($allowedDomains as $domain) {
             if (str_ends_with($this->email, $domain)) {
@@ -146,14 +146,14 @@ class User extends Authenticatable implements FilamentUser
 
 SAB Hero Articles comes with several Blade components for easy UI implementation:
 
-- `<x-sabhero-article::layout>` - Main article layout
-- `<x-sabhero-article::card>` - Article post-card
-- `<x-sabhero-article::feature-card>` - Featured post-card
-- `<x-sabhero-article::breadcrumb>` - Breadcrumb navigation
-- `<x-sabhero-article::header-category>` - Category header
-- `<x-sabhero-article::header-metro>` - Metro-style header
-- `<x-sabhero-article::markdown>` - Markdown content renderer
-- `<x-sabhero-article::recent-post>` - Recent posts display
+- `<x-sabhero-articles::layout>` - Main article layout
+- `<x-sabhero-articles::card>` - Article post-card
+- `<x-sabhero-articles::feature-card>` - Featured post-card
+- `<x-sabhero-articles::breadcrumb>` - Breadcrumb navigation
+- `<x-sabhero-articles::header-category>` - Category header
+- `<x-sabhero-articles::header-metro>` - Metro-style header
+- `<x-sabhero-articles::markdown>` - Markdown content renderer
+- `<x-sabhero-articles::recent-post>` - Recent posts display
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,15 @@
 {
-    "name": "fuelviews/laravel-sabhero-article",
-    "description": "SAB Hero Articles package",
+    "name": "fuelviews/laravel-sabhero-articles",
+    "description": "SAB Hero Articles Package",
     "keywords": [
         "fuelviews",
         "laravel",
         "sabhero",
-        "sabhero-article"
+        "sabhero-articles",
+        "articles",
+        "blog"
     ],
-    "homepage": "https://github.com/fuelviews/laravel-sabhero-article",
+    "homepage": "https://github.com/fuelviews/laravel-sabhero-articles",
     "license": "MIT",
     "authors": [
         {
@@ -41,13 +43,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Fuelviews\\SabHeroArticle\\": "src/",
-            "Fuelviews\\SabHeroArticle\\Database\\Factories\\": "database/factories/"
+            "Fuelviews\\SabHeroArticles\\": "src/",
+            "Fuelviews\\SabHeroArticles\\Database\\Factories\\": "database/factories/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Fuelviews\\SabHeroArticle\\Tests\\": "tests/",
+            "Fuelviews\\SabHeroArticles\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/"
         }
     },
@@ -66,10 +68,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Fuelviews\\SabHeroArticle\\SabHeroArticleServiceProvider"
+                "Fuelviews\\SabHeroArticles\\SabHeroArticlesServiceProvider"
             ],
             "aliases": {
-                "SabHeroArticle": "Fuelviews\\SabHeroArticle\\Facades\\SabHeroArticle"
+                "SabHeroArticles": "Fuelviews\\SabHeroArticles\\Facades\\SabHeroArticles"
             }
         }
     },

--- a/config/feed.php
+++ b/config/feed.php
@@ -11,12 +11,12 @@ return [
              * You can also pass an argument to that method:
              * ['App\Models\Post@getFeedItems', 'argument']
              */
-            'items' => 'Fuelviews\SabHeroArticle\Models\Post@getFeedItems',
+            'items' => 'Fuelviews\SabHeroArticles\Models\Post@getFeedItems',
 
             /*
              * The feed will be available on this url.
              */
-            'url' => config('sabhero-article.route.prefix').'/rss',
+            'url' => config('sabhero-articles.route.prefix').'/rss',
 
             'title' => config('app.name').' Latest Article Posts',
             'description' => 'The latest article posts from '.config('app.url'),
@@ -37,7 +37,7 @@ return [
             /*
              * The view that will render the feed.
              */
-            'view' => 'sabhero-article::feed.rss',
+            'view' => 'sabhero-articles::feed.rss',
 
             /*
              * The type of feed to use: 'atom' or 'rss'

--- a/config/sabhero-articles.php
+++ b/config/sabhero-articles.php
@@ -1,6 +1,6 @@
 <?php
 
-use Fuelviews\SabHeroArticle\Models\User;
+use Fuelviews\SabHeroArticles\Models\User;
 
 return [
     'tables' => [

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Database\Factories;
+namespace Fuelviews\SabHeroArticles\Database\Factories;
 
-use Fuelviews\SabHeroArticle\Models\Category;
+use Fuelviews\SabHeroArticles\Models\Category;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 

--- a/database/factories/CategoryPostFactory.php
+++ b/database/factories/CategoryPostFactory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Database\Factories;
+namespace Fuelviews\SabHeroArticles\Database\Factories;
 
-use Fuelviews\SabHeroArticle\Models\CategoryPost;
+use Fuelviews\SabHeroArticles\Models\CategoryPost;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class CategoryPostFactory extends Factory

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Database\Factories;
+namespace Fuelviews\SabHeroArticles\Database\Factories;
 
-use Fuelviews\SabHeroArticle\Models\Page;
+use Fuelviews\SabHeroArticles\Models\Page;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Database\Factories;
+namespace Fuelviews\SabHeroArticles\Database\Factories;
 
 use Carbon\Carbon;
-use Fuelviews\SabHeroArticle\Enums\PostStatus;
-use Fuelviews\SabHeroArticle\Models\Post;
-use Fuelviews\SabHeroArticle\Models\UserBak;
+use Fuelviews\SabHeroArticles\Enums\PostStatus;
+use Fuelviews\SabHeroArticles\Models\Post;
+use Fuelviews\SabHeroArticles\Models\UserBak;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 

--- a/database/factories/PostTagFactory.php
+++ b/database/factories/PostTagFactory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Database\Factories;
+namespace Fuelviews\SabHeroArticles\Database\Factories;
 
-use Fuelviews\SabHeroArticle\Models\PostTag;
+use Fuelviews\SabHeroArticles\Models\PostTag;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class PostTagFactory extends Factory

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Database\Factories;
+namespace Fuelviews\SabHeroArticles\Database\Factories;
 
-use Fuelviews\SabHeroArticle\Models\Tag;
+use Fuelviews\SabHeroArticles\Models\Tag;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 

--- a/database/migrations/create_article_tables.php
+++ b/database/migrations/create_article_tables.php
@@ -8,14 +8,14 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create(config('sabhero-article.tables.prefix').'categories', function (Blueprint $table) {
+        Schema::create(config('sabhero-articles.tables.prefix').'categories', function (Blueprint $table) {
             $table->id();
             $table->string('name', 155)->unique();
             $table->string('slug', 155)->unique();
             $table->timestamps();
         });
 
-        Schema::create(config('sabhero-article.tables.prefix').'authors', function (Blueprint $table) {
+        Schema::create(config('sabhero-articles.tables.prefix').'authors', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->nullable();
             $table->string('slug')->unique();
@@ -25,7 +25,7 @@ return new class extends Migration
             $table->timestamps();
         });
 
-        Schema::create(config('sabhero-article.tables.prefix').'posts', function (Blueprint $table) {
+        Schema::create(config('sabhero-articles.tables.prefix').'posts', function (Blueprint $table) {
             $table->id();
             $table->string('title');
             $table->string('slug');
@@ -35,37 +35,37 @@ return new class extends Migration
             $table->dateTime('published_at')->nullable();
             $table->dateTime('scheduled_for')->nullable();
             $table->string('feature_image_alt_text');
-            $table->foreignId(config('sabhero-article.user.foreign_key'))
+            $table->foreignId(config('sabhero-articles.user.foreign_key'))
                 ->constrained()
                 ->cascadeOnDelete();
             $table->timestamps();
         });
 
-        Schema::create(config('sabhero-article.tables.prefix').'category_'.config('sabhero-article.tables.prefix').'post', function (Blueprint $table) {
+        Schema::create(config('sabhero-articles.tables.prefix').'category_'.config('sabhero-articles.tables.prefix').'post', function (Blueprint $table) {
             $table->id();
             $table->foreignId('post_id')
-                ->constrained(table: config('sabhero-article.tables.prefix').'posts')
+                ->constrained(table: config('sabhero-articles.tables.prefix').'posts')
                 ->cascadeOnDelete();
             $table->foreignId('category_id')
-                ->constrained(table: config('sabhero-article.tables.prefix').'categories')
+                ->constrained(table: config('sabhero-articles.tables.prefix').'categories')
                 ->cascadeOnDelete();
             $table->timestamps();
         });
 
-        Schema::create(config('sabhero-article.tables.prefix').'tags', function (Blueprint $table) {
+        Schema::create(config('sabhero-articles.tables.prefix').'tags', function (Blueprint $table) {
             $table->id();
             $table->string('name', 50)->unique();
             $table->string('slug', 155)->unique();
             $table->timestamps();
         });
 
-        Schema::create(config('sabhero-article.tables.prefix').'post_'.config('sabhero-article.tables.prefix').'tag', function (Blueprint $table) {
+        Schema::create(config('sabhero-articles.tables.prefix').'post_'.config('sabhero-articles.tables.prefix').'tag', function (Blueprint $table) {
             $table->id();
             $table->foreignId('post_id')
-                ->constrained(table: config('sabhero-article.tables.prefix').'posts')
+                ->constrained(table: config('sabhero-articles.tables.prefix').'posts')
                 ->cascadeOnDelete();
             $table->foreignId('tag_id')
-                ->constrained(table: config('sabhero-article.tables.prefix').'tags')
+                ->constrained(table: config('sabhero-articles.tables.prefix').'tags')
                 ->cascadeOnDelete();
             $table->timestamps();
         });
@@ -77,12 +77,12 @@ return new class extends Migration
     public function down(): void
     {
         Schema::disableForeignKeyConstraints();
-        Schema::dropIfExists(config('sabhero-article.tables.prefix').'category_'.config('sabhero-article.tables.prefix').'post');
-        Schema::dropIfExists(config('sabhero-article.tables.prefix').'categories');
-        Schema::dropIfExists(config('sabhero-article.tables.prefix').'authors');
-        Schema::dropIfExists(config('sabhero-article.tables.prefix').'posts');
-        Schema::dropIfExists(config('sabhero-article.tables.prefix').'tags');
-        Schema::dropIfExists(config('sabhero-article.tables.prefix').'post_'.config('sabhero-article.tables.prefix').'tag');
+        Schema::dropIfExists(config('sabhero-articles.tables.prefix').'category_'.config('sabhero-articles.tables.prefix').'post');
+        Schema::dropIfExists(config('sabhero-articles.tables.prefix').'categories');
+        Schema::dropIfExists(config('sabhero-articles.tables.prefix').'authors');
+        Schema::dropIfExists(config('sabhero-articles.tables.prefix').'posts');
+        Schema::dropIfExists(config('sabhero-articles.tables.prefix').'tags');
+        Schema::dropIfExists(config('sabhero-articles.tables.prefix').'post_'.config('sabhero-articles.tables.prefix').'tag');
         Schema::enableForeignKeyConstraints();
     }
 };

--- a/database/seeders/PageTableSeeder.php
+++ b/database/seeders/PageTableSeeder.php
@@ -3,7 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Fuelviews\SabHeroArticle\Models\Page;
+use Fuelviews\SabHeroArticles\Models\Page;
 
 class PageTableSeeder extends Seeder
 {

--- a/resources/views/articles/authors/index.blade.php
+++ b/resources/views/articles/authors/index.blade.php
@@ -1,11 +1,11 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section class="py-8">
         <div class="container mx-auto">
             <h1 class="text-3xl font-semibold mb-8">Our Authors</h1>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 @foreach ($authors as $user)
                     <div class="bg-white p-6 rounded-lg shadow">
-                        <a href="{{ route('sabhero-article.author.show', ['user' => $user->slug]) }}">
+                        <a href="{{ route('sabhero-articles.author.show', ['user' => $user->slug]) }}">
 
                             <img
                                 class="h-48 w-48 rounded-full mx-auto hover:opacity-65"
@@ -31,4 +31,4 @@
             @endif
         </div>
     </section>
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/articles/authors/show.blade.php
+++ b/resources/views/articles/authors/show.blade.php
@@ -1,9 +1,9 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section class="py-8">
         <div class="container mx-auto">
             <div class="flex flex-col md:flex-row md:items-center gap-8">
                 <div class="flex-shrink-0">
-                    <a href="{{ route('sabhero-article.author.show', $author->slug) }}">
+                    <a href="{{ route('sabhero-articles.author.show', $author->slug) }}">
                         <img
                             class="h-48 w-48 rounded-full shadow-lg"
                             srcset="{{ $author->getAuthorMediaSrcSet() }}"
@@ -67,7 +67,7 @@
                 <div class="">
                     @foreach ($posts->take(1) as $post)
                         <div>
-                            <x-sabhero-article::feature-card :post="$post" />
+                            <x-sabhero-articles::feature-card :post="$post" />
                         </div>
                     @endforeach
                 </div>
@@ -77,7 +77,7 @@
             <div class="container mx-auto">
                 <div class="grid sm:grid-cols-3 gap-x-14 gap-y-14">
                     @foreach ($posts->skip(1) as $post)
-                        <x-sabhero-article::card :post="$post" />
+                        <x-sabhero-articles::card :post="$post" />
                     @endforeach
                 </div>
             </div>
@@ -89,4 +89,4 @@
             </div>
         </div>
     @endif
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/articles/categories/index.blade.php
+++ b/resources/views/articles/categories/index.blade.php
@@ -1,10 +1,10 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section class="py-8">
         <div class="container mx-auto">
             <h1 class="inherits-color text-balance leading-tighter text-3xl font-semibold tracking-tight pb-8">Browse by Category</h1>
             <div class="flex flex-wrap gap-x-2">
                 @foreach($categories as $category)
-                    <x-sabhero-article::category-button :category="$category" size="medium" route="sabhero-article.category.post" />
+                    <x-sabhero-articles::category-button :category="$category" size="medium" route="sabhero-articles.category.post" />
                 @endforeach
             </div>
         </div>
@@ -15,7 +15,7 @@
                 <div class="">
                     @foreach ($posts->take(1) as $post)
                         <div>
-                            <x-sabhero-article::feature-card :post="$post" />
+                            <x-sabhero-articles::feature-card :post="$post" />
                         </div>
                     @endforeach
                 </div>
@@ -25,7 +25,7 @@
             <div class="container mx-auto">
                 <div class="grid sm:grid-cols-3 gap-x-14 gap-y-14">
                     @foreach ($posts->skip(1) as $post)
-                        <x-sabhero-article::card :post="$post" />
+                        <x-sabhero-articles::card :post="$post" />
                     @endforeach
                 </div>
                 <div class="mt-8">
@@ -40,4 +40,4 @@
             </div>
         </div>
     @endif
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/articles/categories/show.blade.php
+++ b/resources/views/articles/categories/show.blade.php
@@ -1,4 +1,4 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section class="py-8">
         <header class="container mx-auto text-left">
             <p class="inherits-color text-balance leading-tighter relative z-10 text-3xl font-semibold tracking-tight">
@@ -12,7 +12,7 @@
                 <div class="">
                     @foreach ($posts->take(1) as $post)
                         <div>
-                            <x-sabhero-article::feature-card :post="$post" />
+                            <x-sabhero-articles::feature-card :post="$post" />
                         </div>
                     @endforeach
                 </div>
@@ -22,7 +22,7 @@
             <div class="container mx-auto">
                 <div class="grid sm:grid-cols-3 gap-x-14 gap-y-14">
                     @foreach ($posts->skip(1) as $post)
-                        <x-sabhero-article::card :post="$post" />
+                        <x-sabhero-articles::card :post="$post" />
                     @endforeach
                 </div>
                 <div class="mt-8">
@@ -37,4 +37,4 @@
             </div>
         </div>
     @endif
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/articles/index.blade.php
+++ b/resources/views/articles/index.blade.php
@@ -1,8 +1,8 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section class="py-8">
         <div class="container mx-auto">
             <!-- Filter Section -->
-            <x-sabhero-article::article-filters
+            <x-sabhero-articles::article-filters
                 :categories="$categories"
                 :tags="$tags"
                 :authors="$authors"
@@ -12,7 +12,7 @@
                 :search-term="$searchTerm"
             />
 
-            <h1 class="text-4xl font-bold mb-4 lg:mb-8">{{ str(config('sabhero-article.route.prefix'))->plural()->ucfirst() }}</h1>
+            <h1 class="text-4xl font-bold mb-4 lg:mb-8">{{ str(config('sabhero-articles.route.prefix'))->plural()->ucfirst() }}</h1>
         </div>
     </section>
 
@@ -23,7 +23,7 @@
                     <div class="">
                         @foreach ($posts->take(1) as $post)
                             <div>
-                                <x-sabhero-article::feature-card :post="$post" />
+                                <x-sabhero-articles::feature-card :post="$post" />
                             </div>
                         @endforeach
                     </div>
@@ -36,11 +36,11 @@
                 <div class="container mx-auto">
                     <div class="grid sm:grid-cols-3 gap-x-14 gap-y-14">
                         @foreach ($posts->skip(1) as $post)
-                            <x-sabhero-article::card :post="$post" />
+                            <x-sabhero-articles::card :post="$post" />
                         @endforeach
                     </div>
                     <div class="mt-8">
-                        {{ $posts->links('sabhero-article::pagination.tailwind') }}
+                        {{ $posts->links('sabhero-articles::pagination.tailwind') }}
                     </div>
                 </div>
             </section>
@@ -58,4 +58,4 @@
             </div>
         </section>
     @endif
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/articles/search.blade.php
+++ b/resources/views/articles/search.blade.php
@@ -1,4 +1,4 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section>
         <header class="container mx-auto mb-4 max-w-[800px] px-6 pb-4 mt-10 text-center">
             <h3 class="inherits-color text-balance leading-tighter relative z-10 text-5xl font-semibold tracking-tight">
@@ -10,7 +10,7 @@
         <div class="container mx-auto">
             <div class="grid grid-cols-3 gap-x-14 gap-y-14">
                 @forelse ($posts as $post)
-                   <x-sabhero-article::card :post="$post"/>
+                   <x-sabhero-articles::card :post="$post"/>
                     @empty
                         <div class="flex col-span-3 justify-center w-full">
                             <h2 class="text-2xl text-gray-300 font-semibold">No posts found</h2>
@@ -23,4 +23,4 @@
         </div>
     </section>
 
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -1,4 +1,4 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section class="py-8">
         <div class="container mx-auto">
             <div class="mx-auto mb-12 space-y-10">
@@ -28,18 +28,18 @@
                                             </p>
                                             <p>{{ $post->sub_title }}</p>
                                         </div>
-                                        <x-sabhero-article-markdown :content="$post->body" />
+                                        <x-sabhero-articles-markdown :content="$post->body" />
                                     </article>
                                 </div>
                                 <hr class="my-12 h-[2px] border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-200">
                                 <div class="flex flex-wrap items-center gap-4">
-                                    <x-sabhero-article::author-profile :user="$post->user" :post="$post" size="large" />
+                                    <x-sabhero-articles::author-profile :user="$post->user" :post="$post" size="large" />
                                     <div class="flex flex-wrap gap-2 min-w-0 flex-1 justify-end">
                                         @foreach ($post->categories as $category)
-                                            <x-sabhero-article::category-button :category="$category" size="medium" />
+                                            <x-sabhero-articles::category-button :category="$category" size="medium" />
                                         @endforeach
                                         @foreach ($post->tags as $tag)
-                                            <x-sabhero-article::tag-button :tag="$tag" size="medium" />
+                                            <x-sabhero-articles::tag-button :tag="$tag" size="medium" />
                                         @endforeach
                                     </div>
                                 </div>
@@ -60,7 +60,7 @@
                     </div>
                     <div class="grid md:grid-cols-3 sm:grid-cols-1 gap-x-12 gap-y-10">
                         @forelse($post->relatedPosts() as $post)
-                            <x-sabhero-article::card :post="$post" />
+                            <x-sabhero-articles::card :post="$post" />
                         @empty
                         <div class="col-span-3">
                             <p class="text-center text-xl font-semibold text-gray-300">No related posts found.</p>
@@ -72,4 +72,4 @@
             </div>
         </div>
     </section>
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/articles/tags/index.blade.php
+++ b/resources/views/articles/tags/index.blade.php
@@ -1,10 +1,10 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section class="py-8">
         <div class="container mx-auto">
             <h2 class="inherits-color text-balance leading-tighter text-3xl font-semibold tracking-tight pb-8">Browse by Tag</h2>
             <div class="flex flex-wrap gap-x-2">
                 @foreach($tags as $tag)
-                    <x-sabhero-article::tag-button :tag="$tag" size="medium" route="sabhero-article.tag.post" />
+                    <x-sabhero-articles::tag-button :tag="$tag" size="medium" route="sabhero-articles.tag.post" />
                 @endforeach
             </div>
         </div>
@@ -15,7 +15,7 @@
                 <div class="">
                     @foreach ($posts->take(1) as $post)
                         <div>
-                            <x-sabhero-article::feature-card :post="$post" />
+                            <x-sabhero-articles::feature-card :post="$post" />
                         </div>
                     @endforeach
                 </div>
@@ -25,7 +25,7 @@
             <div class="container mx-auto">
                 <div class="grid sm:grid-cols-3 gap-x-14 gap-y-14">
                     @foreach ($posts->skip(1) as $post)
-                        <x-sabhero-article::card :post="$post" />
+                        <x-sabhero-articles::card :post="$post" />
                     @endforeach
                 </div>
                 <div class="mt-8">
@@ -40,4 +40,4 @@
             </div>
         </div>
     @endif
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/articles/tags/show.blade.php
+++ b/resources/views/articles/tags/show.blade.php
@@ -1,4 +1,4 @@
-<x-sabhero-article-layout>
+<x-sabhero-articles-layout>
     <section class="py-8">
         <header class="container mx-auto">
             <p class="inherits-color text-balance leading-tighter text-3xl font-semibold tracking-tight">
@@ -12,7 +12,7 @@
                 <div class="">
                     @foreach ($posts->take(1) as $post)
                         <div>
-                            <x-sabhero-article::feature-card :post="$post" />
+                            <x-sabhero-articles::feature-card :post="$post" />
                         </div>
                     @endforeach
                 </div>
@@ -22,7 +22,7 @@
             <div class="container mx-auto">
                 <div class="grid sm:grid-cols-3 gap-x-14 gap-y-14">
                     @foreach ($posts->skip(1) as $post)
-                        <x-sabhero-article::card :post="$post" />
+                        <x-sabhero-articles::card :post="$post" />
                     @endforeach
                 </div>
                 <div class="mt-8">
@@ -37,4 +37,4 @@
             </div>
         </div>
     @endif
-</x-sabhero-article-layout>
+</x-sabhero-articles-layout>

--- a/resources/views/components/article-filters.blade.php
+++ b/resources/views/components/article-filters.blade.php
@@ -17,13 +17,13 @@
     <div class="p-4 sm:p-5 lg:p-6">
         <h2 class="hidden lg:block text-lg font-medium text-gray-900 mb-4">Search & Filter</h2>
 
-        <form method="GET" action="{{ route('sabhero-article.post.index') }}" class="space-y-4">
+        <form method="GET" action="{{ route('sabhero-articles.post.index') }}" class="space-y-4">
             <!-- Mobile Search Only -->
             <div class="lg:hidden">
                 <div>
                     <label for="search-mobile" class="block text-sm font-medium text-gray-700 mb-2">Search</label>
                     @if(class_exists('\Livewire\Livewire') && !app()->environment('testing'))
-                        <livewire:sabhero-article::search-autocomplete :initial-search="$searchTerm" />
+                        <livewire:sabhero-articles::search-autocomplete :initial-search="$searchTerm" />
                     @else
                         <div class="relative">
                             <button type="submit" class="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400 hover:text-blue-500 transition-colors z-10">
@@ -49,7 +49,7 @@
                 <div class="w-auto lg:w-64 lg:pr-6 self-start">
                     <label for="search" class="block text-sm font-medium text-gray-700 mb-2">Search</label>
                     @if(class_exists('\Livewire\Livewire') && !app()->environment('testing'))
-                        <livewire:sabhero-article::search-autocomplete :initial-search="$searchTerm" />
+                        <livewire:sabhero-articles::search-autocomplete :initial-search="$searchTerm" />
                     @else
                         <div class="relative">
                             <button type="submit" class="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400 hover:text-blue-500 transition-colors z-10">
@@ -181,7 +181,7 @@
                         @endif
                     </div>
 
-                    <button type="button" onclick="window.location.href='{{ route('sabhero-article.post.index') }}'" class="inline-flex items-center px-3 py-1 text-sm text-gray-600 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-700 transition-colors duration-150 self-start sm:self-auto">
+                    <button type="button" onclick="window.location.href='{{ route('sabhero-articles.post.index') }}'" class="inline-flex items-center px-3 py-1 text-sm text-gray-600 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-700 transition-colors duration-150 self-start sm:self-auto">
                         × Reset All
                     </button>
                 </div>

--- a/resources/views/components/author-profile.blade.php
+++ b/resources/views/components/author-profile.blade.php
@@ -31,7 +31,7 @@
 @endphp
 
 <div class="flex items-center {{ $containerClasses }}" {{ $attributes }}>
-    <a href="{{ route('sabhero-article.author.show', ['user' => $user->slug]) }}" title="{{ $user->name() }}" class="hover:opacity-65">
+    <a href="{{ route('sabhero-articles.author.show', ['user' => $user->slug]) }}" title="{{ $user->name() }}" class="hover:opacity-65">
         <img
             class="{{ $avatarClasses }} overflow-hidden rounded-full object-cover text-[0]"
             srcset="{{ $user->getAuthorMediaSrcSet() }}"
@@ -40,7 +40,7 @@
         >
     </a>
     <div class="min-w-0">
-        <a href="{{ route('sabhero-article.author.show', ['user' => $user->slug]) }}" title="{{ $user->name() }}"
+        <a href="{{ route('sabhero-articles.author.show', ['user' => $user->slug]) }}" title="{{ $user->name() }}"
            class="block overflow-hidden text-ellipsis whitespace-nowrap hover:text-prime {{ $nameClasses }}">
             {{ $user->name() }}
         </a>

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -3,7 +3,7 @@
 <div class="flex flex-col gap-y-8 h-full">
     <div class="h-[250px] w-full rounded-xl overflow-hidden shadow-xl">
         @if ($post->hasMedia('post_feature_image'))
-            <a href="{{ route('sabhero-article.post.show', ['post' => $post->slug]) }}"
+            <a href="{{ route('sabhero-articles.post.show', ['post' => $post->slug]) }}"
                     class="hover:opacity-65">
                 <img
                     srcset="{{ $post->getFirstMedia('post_feature_image')->getSrcset() }}"
@@ -20,7 +20,7 @@
         <div>
             <h2 title="{{ $post->title }}"
                 class="hover:text-prime mb-3 line-clamp-2 text-xl font-semibold">
-                <a href="{{ route('sabhero-article.post.show', ['post' => $post->slug]) }}">
+                <a href="{{ route('sabhero-articles.post.show', ['post' => $post->slug]) }}">
                     {{ $post->title }}
                 </a>
             </h2>
@@ -34,14 +34,14 @@
         <div class="mt-auto">
             <div class="mt-3 flex flex-wrap gap-2">
                 @foreach ($post->categories->take(1) as $category)
-                    <x-sabhero-article::category-button :category="$category" size="small" />
+                    <x-sabhero-articles::category-button :category="$category" size="small" />
                 @endforeach
                 @foreach ($post->tags->take(1) as $tag)
-                    <x-sabhero-article::tag-button :tag="$tag" size="small" />
+                    <x-sabhero-articles::tag-button :tag="$tag" size="small" />
                 @endforeach
             </div>
             <div class="mt-4 md:mt-6">
-                <x-sabhero-article::author-profile :user="$post->user" :post="$post" size="medium" />
+                <x-sabhero-articles::author-profile :user="$post->user" :post="$post" size="medium" />
             </div>
         </div>
     </div>

--- a/resources/views/components/category-button.blade.php
+++ b/resources/views/components/category-button.blade.php
@@ -1,4 +1,4 @@
-@props(['category', 'size' => 'small', 'route' => 'sabhero-article.post.index'])
+@props(['category', 'size' => 'small', 'route' => 'sabhero-articles.post.index'])
 
 @php
     $sizeClasses = match($size) {
@@ -11,7 +11,7 @@
         default => 'mr-1 h-3 w-3'
     };
 
-    $routeParams = $route === 'sabhero-article.category.post'
+    $routeParams = $route === 'sabhero-articles.category.post'
         ? ['category' => $category->slug]
         : ['category' => $category->slug];
 @endphp

--- a/resources/views/components/feature-card.blade.php
+++ b/resources/views/components/feature-card.blade.php
@@ -3,7 +3,7 @@
 <div class="grid sm:grid-cols-2 gap-y-5 gap-x-10">
     <div class="md:h-[400px] w-full overflow-hidden rounded-2xl shadow-2xl">
         @if ($post->hasMedia('post_feature_image'))
-            <a href="{{ route('sabhero-article.post.show', ['post' => $post->slug]) }}"
+            <a href="{{ route('sabhero-articles.post.show', ['post' => $post->slug]) }}"
                     class="hover:opacity-65">
                 <img
                     srcset="{{ $post->getFirstMedia('post_feature_image')->getSrcset() }}"
@@ -19,7 +19,7 @@
     <div class="flex flex-col justify-between py-4 sm:pl-10 h-full">
         <div>
             <div class="mb-5">
-                <a href="{{ route('sabhero-article.post.show', ['post' => $post->slug]) }}" class="mb-4 block text-xl md:text-4xl font-semibold hover:text-prime">
+                <a href="{{ route('sabhero-articles.post.show', ['post' => $post->slug]) }}" class="mb-4 block text-xl md:text-4xl font-semibold hover:text-prime">
                     {{ $post->title }}
                 </a>
             </div>
@@ -33,14 +33,14 @@
         <div class="mt-auto space-y-4">
             <div class="mt-3 flex flex-wrap gap-2">
                 @foreach ($post->categories->take(1) as $category)
-                    <x-sabhero-article::category-button :category="$category" size="medium" />
+                    <x-sabhero-articles::category-button :category="$category" size="medium" />
                 @endforeach
                 @foreach ($post->tags->take(1) as $tag)
-                    <x-sabhero-article::tag-button :tag="$tag" size="medium" />
+                    <x-sabhero-articles::tag-button :tag="$tag" size="medium" />
                 @endforeach
             </div>
             <div class="pt-1">
-                <x-sabhero-article::author-profile :user="$post->user" :post="$post" size="large" />
+                <x-sabhero-articles::author-profile :user="$post->user" :post="$post" size="large" />
             </div>
         </div>
     </div>

--- a/resources/views/components/header-category.blade.php
+++ b/resources/views/components/header-category.blade.php
@@ -2,7 +2,7 @@
     <div class="relative z-0 rounded-2xl border bg-white py-4 shadow-xl">
         <div class="max-h-[65vh] list-none overflow-y-auto transition-all duration-300 translate-y-0 opacity-100">
             @foreach($categories as $category)
-                <a href="{{ route('sabhero-article.post.index', ['category' => $category->slug]) }}"
+                <a href="{{ route('sabhero-articles.post.index', ['category' => $category->slug]) }}"
                    class="py-2 block text-sm font-medium transition-all duration-300 cursor-pointer hover:text-prime-700 px-6 capitalize"
                 >
                     {{ $category->name }}

--- a/resources/views/components/tag-button.blade.php
+++ b/resources/views/components/tag-button.blade.php
@@ -1,4 +1,4 @@
-@props(['tag', 'size' => 'small', 'route' => 'sabhero-article.post.index'])
+@props(['tag', 'size' => 'small', 'route' => 'sabhero-articles.post.index'])
 
 @php
     $sizeClasses = match($size) {
@@ -11,7 +11,7 @@
         default => 'mr-1 h-3 w-3'
     };
 
-    $routeParams = $route === 'sabhero-article.tag.post'
+    $routeParams = $route === 'sabhero-articles.tag.post'
         ? ['tag' => $tag->slug]
         : ['tag' => $tag->slug];
 @endphp

--- a/resources/views/filament/tables/columns/user-avatar.blade.php
+++ b/resources/views/filament/tables/columns/user-avatar.blade.php
@@ -6,7 +6,7 @@
     <div class="flex gap-2 items-center">
         <img
             src="{{ $record->avatar }}"
-            alt="{{ $record->{config('sabhero-article.user.columns.name')} }}" class="w-7 h-7 rounded-full">
+            alt="{{ $record->{config('sabhero-articles.user.columns.name')} }}" class="w-7 h-7 rounded-full">
         <p class="text-xs font-semibold text-green-500">{{ $record->name }}</p>
     </div>
 </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,10 +7,10 @@
             @include($componentPath)
         @endif
         <section class="max-w-standard mx-auto px-2 sm:px-3 md:px-4 lg:px-4 xl:px-4 my-2 md:my-6 lg:my-12">
-            <a id="{{ $dynamicAnchorLink }}" class="{{ config('sabhero-article.heading_permalink.html_class') }}"></a>
+            <a id="{{ $dynamicAnchorLink }}" class="{{ config('sabhero-articles.heading_permalink.html_class') }}"></a>
             @if(!empty(\Diglactic\Breadcrumbs\Breadcrumbs::exists()))
                 <section>
-                    <x-sabhero-article::breadcrumb />
+                    <x-sabhero-articles::breadcrumb />
                 </section>
             @endif
             {{ $slot }}

--- a/resources/views/mails/article-published.blade.php
+++ b/resources/views/mails/article-published.blade.php
@@ -84,7 +84,7 @@
     <div class="content">
         <h2>{{ $post->title }}</h2>
         <p>{!! Str::limit($post->body, 500) !!} </p>
-        <a href="{{route('sabhero-article.post.show', ['post' => $post->slug])}}" class="btn">Read More</a>
+        <a href="{{route('sabhero-articles.post.show', ['post' => $post->slug])}}" class="btn">Read More</a>
     </div>
     <div class="footer">
         <p>Thank you for subscribing to our article updates!</p>

--- a/resources/views/pagination/tailwind.blade.php
+++ b/resources/views/pagination/tailwind.blade.php
@@ -1,23 +1,23 @@
 @if ($paginator->hasPages())
     @php
-        $baseUrl = route('sabhero-article.post.index');
-        $prefix = config('sabhero-article.route.prefix');
-        
+        $baseUrl = route('sabhero-articles.post.index');
+        $prefix = config('sabhero-articles.route.prefix');
+
         function customPageUrl($page, $baseUrl, $prefix) {
             if ($page == 1) {
                 $url = $baseUrl;
             } else {
                 $url = str_replace('/' . $prefix, '/' . $prefix . '/page/' . $page, $baseUrl);
             }
-            
+
             // Preserve query parameters
             $queryParams = request()->query();
             unset($queryParams['page']); // Remove the default page parameter
-            
+
             if (!empty($queryParams)) {
                 $url .= '?' . http_build_query($queryParams);
             }
-            
+
             return $url;
         }
     @endphp

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -14,44 +14,44 @@ Breadcrumbs::for('home', static function ($trail) {
     ]);
 });
 
-Breadcrumbs::for('sabhero-article.post.index', static function (BreadcrumbTrail $trail) {
-    $prefix = config('sabhero-article.route.prefix');
+Breadcrumbs::for('sabhero-articles.post.index', static function (BreadcrumbTrail $trail) {
+    $prefix = config('sabhero-articles.route.prefix');
 
     $trail->parent('home');
-    $trail->push(Str::title($prefix), route('sabhero-article.post.index'));
+    $trail->push(Str::title($prefix), route('sabhero-articles.post.index'));
 });
 
-Breadcrumbs::for('sabhero-article.post.show', static function (BreadcrumbTrail $trail, $post) {
-    $trail->parent('sabhero-article.post.index');
-    $trail->push($post->title, route('sabhero-article.post.show', $post->slug));
+Breadcrumbs::for('sabhero-articles.post.show', static function (BreadcrumbTrail $trail, $post) {
+    $trail->parent('sabhero-articles.post.index');
+    $trail->push($post->title, route('sabhero-articles.post.show', $post->slug));
 });
 
-Breadcrumbs::for('sabhero-article.category.index', static function (BreadcrumbTrail $trail) {
+Breadcrumbs::for('sabhero-articles.category.index', static function (BreadcrumbTrail $trail) {
     $trail->parent('home');
-    $trail->push('Categories', route('sabhero-article.category.index'));
+    $trail->push('Categories', route('sabhero-articles.category.index'));
 });
 
-Breadcrumbs::for('sabhero-article.category.post', static function (BreadcrumbTrail $trail, $category) {
-    $trail->parent('sabhero-article.category.index');
-    $trail->push($category->name, route('sabhero-article.category.post', $category->slug));
+Breadcrumbs::for('sabhero-articles.category.post', static function (BreadcrumbTrail $trail, $category) {
+    $trail->parent('sabhero-articles.category.index');
+    $trail->push($category->name, route('sabhero-articles.category.post', $category->slug));
 });
 
-Breadcrumbs::for('sabhero-article.tag.post', static function (BreadcrumbTrail $trail, $tag) {
-    $trail->parent('sabhero-article.tag.index');
-    $trail->push($tag->name, route('sabhero-article.tag.post', $tag->slug));
+Breadcrumbs::for('sabhero-articles.tag.post', static function (BreadcrumbTrail $trail, $tag) {
+    $trail->parent('sabhero-articles.tag.index');
+    $trail->push($tag->name, route('sabhero-articles.tag.post', $tag->slug));
 });
 
-Breadcrumbs::for('sabhero-article.tag.index', static function (BreadcrumbTrail $trail) {
+Breadcrumbs::for('sabhero-articles.tag.index', static function (BreadcrumbTrail $trail) {
     $trail->parent('home');
-    $trail->push('Tags', route('sabhero-article.tag.index'));
+    $trail->push('Tags', route('sabhero-articles.tag.index'));
 });
 
-Breadcrumbs::for('sabhero-article.author.index', static function (BreadcrumbTrail $trail) {
+Breadcrumbs::for('sabhero-articles.author.index', static function (BreadcrumbTrail $trail) {
     $trail->parent('home');
-    $trail->push('Authors', route('sabhero-article.author.index'));
+    $trail->push('Authors', route('sabhero-articles.author.index'));
 });
 
-Breadcrumbs::for('sabhero-article.author.show', static function (BreadcrumbTrail $trail, $author) {
-    $trail->parent('sabhero-article.author.index');
-    $trail->push($author->name, route('sabhero-article.author.show', $author->slug));
+Breadcrumbs::for('sabhero-articles.author.show', static function (BreadcrumbTrail $trail, $author) {
+    $trail->parent('sabhero-articles.author.index');
+    $trail->push($author->name, route('sabhero-articles.author.show', $author->slug));
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,34 +1,34 @@
 <?php
 
-use Fuelviews\SabHeroArticle\Http\Controllers\AuthorController;
-use Fuelviews\SabHeroArticle\Http\Controllers\CategoryController;
-use Fuelviews\SabHeroArticle\Http\Controllers\PostController;
-use Fuelviews\SabHeroArticle\Http\Controllers\TagController;
+use Fuelviews\SabHeroArticles\Http\Controllers\AuthorController;
+use Fuelviews\SabHeroArticles\Http\Controllers\CategoryController;
+use Fuelviews\SabHeroArticles\Http\Controllers\PostController;
+use Fuelviews\SabHeroArticles\Http\Controllers\TagController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(config('sabhero-article.route.middleware'))
-    ->prefix(config('sabhero-article.route.prefix'))
+Route::middleware(config('sabhero-articles.route.middleware'))
+    ->prefix(config('sabhero-articles.route.prefix'))
     ->group(function () {
         Route::get('/', [PostController::class, 'index'])
-            ->name('sabhero-article.post.index');
+            ->name('sabhero-articles.post.index');
         Route::get('/page/{page}', [PostController::class, 'index'])
             ->where('page', '[0-9]+')
-            ->name('sabhero-article.post.page');
+            ->name('sabhero-articles.post.page');
         Route::get('/search', [PostController::class, 'search'])
-            ->name('sabhero-article.post.search');
+            ->name('sabhero-articles.post.search');
         Route::get('/tags', [TagController::class, 'allTags'])
-            ->name('sabhero-article.tag.index');
+            ->name('sabhero-articles.tag.index');
         Route::get('/categories', [CategoryController::class, 'allCategories'])
-            ->name('sabhero-article.category.index');
+            ->name('sabhero-articles.category.index');
         Route::get('/authors', [AuthorController::class, 'allAuthors'])
-            ->name('sabhero-article.author.index');
+            ->name('sabhero-articles.author.index');
         Route::get('/authors/{user:slug}', [AuthorController::class, 'posts'])
-            ->name('sabhero-article.author.show');
+            ->name('sabhero-articles.author.show');
         Route::feeds();
         Route::get('/{post:slug}', [PostController::class, 'show'])
-            ->name('sabhero-article.post.show');
+            ->name('sabhero-articles.post.show');
         Route::get('/categories/{category:slug}', [CategoryController::class, 'posts'])
-            ->name('sabhero-article.category.post');
+            ->name('sabhero-articles.category.post');
         Route::get('/tags/{tag:slug}', [TagController::class, 'posts'])
-            ->name('sabhero-article.tag.post');
+            ->name('sabhero-articles.tag.post');
     });

--- a/src/Components/Breadcrumb.php
+++ b/src/Components/Breadcrumb.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Components;
+namespace Fuelviews\SabHeroArticles\Components;
 
 use Closure;
 use Illuminate\Contracts\View\View;
@@ -10,6 +10,6 @@ class Breadcrumb extends Component
 {
     public function render(): View|Closure|string
     {
-        return view('sabhero-article::components.breadcrumb');
+        return view('sabhero-articles::components.breadcrumb');
     }
 }

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Components;
+namespace Fuelviews\SabHeroArticles\Components;
 
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
@@ -9,6 +9,6 @@ class Card extends Component
 {
     public function render(): View
     {
-        return view('sabhero-article::components.card');
+        return view('sabhero-articles::components.card');
     }
 }

--- a/src/Components/FeatureCard.php
+++ b/src/Components/FeatureCard.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Components;
+namespace Fuelviews\SabHeroArticles\Components;
 
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
@@ -9,6 +9,6 @@ class FeatureCard extends Component
 {
     public function render(): View
     {
-        return view('sabhero-article::components.feature-card');
+        return view('sabhero-articles::components.feature-card');
     }
 }

--- a/src/Components/HeaderCategory.php
+++ b/src/Components/HeaderCategory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Components;
+namespace Fuelviews\SabHeroArticles\Components;
 
-use Fuelviews\SabHeroArticle\Models\Category;
+use Fuelviews\SabHeroArticles\Models\Category;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 
@@ -10,7 +10,7 @@ class HeaderCategory extends Component
 {
     public function render(): View
     {
-        return view('sabhero-article::components.header-category', [
+        return view('sabhero-articles::components.header-category', [
             'categories' => Category::all(),
         ]);
     }

--- a/src/Components/Layout.php
+++ b/src/Components/Layout.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Components;
+namespace Fuelviews\SabHeroArticles\Components;
 
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Route;
@@ -47,6 +47,6 @@ class Layout extends Component
 
     public function render(): View
     {
-        return view('sabhero-article::layouts.app');
+        return view('sabhero-articles::layouts.app');
     }
 }

--- a/src/Components/Markdown.php
+++ b/src/Components/Markdown.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Components;
+namespace Fuelviews\SabHeroArticles\Components;
 
-use Fuelviews\SabHeroArticle\Renderers\GlideImageRenderer;
-use Fuelviews\SabHeroArticle\Renderers\TableOfContentsRenderer;
+use Fuelviews\SabHeroArticles\Renderers\GlideImageRenderer;
+use Fuelviews\SabHeroArticles\Renderers\TableOfContentsRenderer;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Config;
 use Illuminate\View\Component;
@@ -35,8 +35,8 @@ class Markdown extends Component
 
     public function render(): View
     {
-        $headingConfig = Config::get('sabhero-article.heading_permalink', []);
-        $glideConfig = Config::get('sabhero-article.glide', []);
+        $headingConfig = Config::get('sabhero-articles.heading_permalink', []);
+        $glideConfig = Config::get('sabhero-articles.glide', []);
 
         $config = [
             'table_of_contents' => [
@@ -115,7 +115,7 @@ class Markdown extends Component
 
         $html = $converter->convert($this->content)->getContent();
 
-        return view('sabhero-article::components.markdown', [
+        return view('sabhero-articles::components.markdown', [
             'html' => $html,
         ]);
     }

--- a/src/Components/RecentPost.php
+++ b/src/Components/RecentPost.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Components;
+namespace Fuelviews\SabHeroArticles\Components;
 
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 
@@ -12,7 +12,7 @@ class RecentPost extends Component
     {
         $posts = Post::query()->published()->whereNot('slug', request('post')->slug)->latest()->take(5)->get();
 
-        return view('sabhero-article::components.recent-post', [
+        return view('sabhero-articles::components.recent-post', [
             'posts' => $posts,
         ]);
     }

--- a/src/Concerns/HasCategories.php
+++ b/src/Concerns/HasCategories.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Concerns;
+namespace Fuelviews\SabHeroArticles\Concerns;
 
-use Fuelviews\SabHeroArticle\Models\Category;
+use Fuelviews\SabHeroArticles\Models\Category;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 

--- a/src/Enums/PostStatus.php
+++ b/src/Enums/PostStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Enums;
+namespace Fuelviews\SabHeroArticles\Enums;
 
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;

--- a/src/Events/ArticlePublished.php
+++ b/src/Events/ArticlePublished.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Events;
+namespace Fuelviews\SabHeroArticles\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;

--- a/src/Exceptions/CannotSendEmail.php
+++ b/src/Exceptions/CannotSendEmail.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Exceptions;
+namespace Fuelviews\SabHeroArticles\Exceptions;
 
 use Exception;
 

--- a/src/Facades/SabHeroArticle.php
+++ b/src/Facades/SabHeroArticle.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Facades;
+namespace Fuelviews\SabHeroArticles\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \Fuelviews\SabHeroArticle\SabHeroArticle
+ * @see \Fuelviews\SabHeroArticles\SabHeroArticles
  */
-class SabHeroArticle extends Facade
+class SabHeroArticles extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return \Fuelviews\SabHeroArticle\SabHeroArticle::class;
+        return \Fuelviews\SabHeroArticles\SabHeroArticles::class;
     }
 }

--- a/src/Filament/Resources/CategoryResource.php
+++ b/src/Filament/Resources/CategoryResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources;
+namespace Fuelviews\SabHeroArticles\Filament\Resources;
 
 use Filament\Forms\Form;
 use Filament\Infolists\Components\Section;
@@ -9,11 +9,11 @@ use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\Pages\EditCategory;
-use Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\Pages\ListCategories;
-use Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\Pages\ViewCategory;
-use Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\RelationManagers\PostsRelationManager;
-use Fuelviews\SabHeroArticle\Models\Category;
+use Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\Pages\EditCategory;
+use Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\Pages\ListCategories;
+use Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\Pages\ViewCategory;
+use Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\RelationManagers\PostsRelationManager;
+use Fuelviews\SabHeroArticles\Models\Category;
 
 class CategoryResource extends Resource
 {

--- a/src/Filament/Resources/CategoryResource/Pages/CreateCategory.php
+++ b/src/Filament/Resources/CategoryResource/Pages/CreateCategory.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource;
 
 class CreateCategory extends CreateRecord
 {

--- a/src/Filament/Resources/CategoryResource/Pages/EditCategory.php
+++ b/src/Filament/Resources/CategoryResource/Pages/EditCategory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource;
 
 class EditCategory extends EditRecord
 {

--- a/src/Filament/Resources/CategoryResource/Pages/ListCategories.php
+++ b/src/Filament/Resources/CategoryResource/Pages/ListCategories.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
-use Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource;
 
 class ListCategories extends ListRecords
 {

--- a/src/Filament/Resources/CategoryResource/Pages/ViewCategory.php
+++ b/src/Filament/Resources/CategoryResource/Pages/ViewCategory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\Pages;
 
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource;
-use Fuelviews\SabHeroArticle\Models\Category;
+use Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource;
+use Fuelviews\SabHeroArticles\Models\Category;
 
 class ViewCategory extends ViewRecord
 {

--- a/src/Filament/Resources/CategoryResource/RelationManagers/PostsRelationManager.php
+++ b/src/Filament/Resources/CategoryResource/RelationManagers/PostsRelationManager.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\CategoryResource\RelationManagers;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\CategoryResource\RelationManagers;
 
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Support\Str;
 
 class PostsRelationManager extends RelationManager

--- a/src/Filament/Resources/PageResource.php
+++ b/src/Filament/Resources/PageResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources;
+namespace Fuelviews\SabHeroArticles\Filament\Resources;
 
 use Filament\Forms\Form;
 use Filament\Infolists\Components\Section;
@@ -10,11 +10,11 @@ use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Fuelviews\SabHeroArticle\Filament\Resources\PageResource\Pages\CreatePage;
-use Fuelviews\SabHeroArticle\Filament\Resources\PageResource\Pages\EditPage;
-use Fuelviews\SabHeroArticle\Filament\Resources\PageResource\Pages\ListPages;
-use Fuelviews\SabHeroArticle\Filament\Resources\PageResource\Pages\ViewPage;
-use Fuelviews\SabHeroArticle\Models\Page;
+use Fuelviews\SabHeroArticles\Filament\Resources\PageResource\Pages\CreatePage;
+use Fuelviews\SabHeroArticles\Filament\Resources\PageResource\Pages\EditPage;
+use Fuelviews\SabHeroArticles\Filament\Resources\PageResource\Pages\ListPages;
+use Fuelviews\SabHeroArticles\Filament\Resources\PageResource\Pages\ViewPage;
+use Fuelviews\SabHeroArticles\Models\Page;
 
 class PageResource extends Resource
 {

--- a/src/Filament/Resources/PageResource/Pages/CreatePage.php
+++ b/src/Filament/Resources/PageResource/Pages/CreatePage.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PageResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PageResource\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\PageResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\PageResource;
 
 class CreatePage extends CreateRecord
 {

--- a/src/Filament/Resources/PageResource/Pages/EditPage.php
+++ b/src/Filament/Resources/PageResource/Pages/EditPage.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PageResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PageResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\PageResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\PageResource;
 
 class EditPage extends EditRecord
 {

--- a/src/Filament/Resources/PageResource/Pages/ListPages.php
+++ b/src/Filament/Resources/PageResource/Pages/ListPages.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PageResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PageResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
-use Fuelviews\SabHeroArticle\Filament\Resources\PageResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\PageResource;
 
 class ListPages extends ListRecords
 {

--- a/src/Filament/Resources/PageResource/Pages/ViewPage.php
+++ b/src/Filament/Resources/PageResource/Pages/ViewPage.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PageResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PageResource\Pages;
 
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\PageResource;
-use Fuelviews\SabHeroArticle\Models\Page;
+use Fuelviews\SabHeroArticles\Filament\Resources\PageResource;
+use Fuelviews\SabHeroArticles\Models\Page;
 
 class ViewPage extends ViewRecord
 {

--- a/src/Filament/Resources/PostResource.php
+++ b/src/Filament/Resources/PostResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources;
+namespace Fuelviews\SabHeroArticles\Filament\Resources;
 
 use App\Models\User;
 use Filament\Forms;
@@ -16,17 +16,17 @@ use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-// use Fuelviews\SabHeroArticle\Enums\MetroType;
-use Fuelviews\SabHeroArticle\Enums\PostStatus;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Pages\CreatePost;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Pages\EditPost;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Pages\ListPosts;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Pages\ViewPost;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Widgets\ArticlePostPublishedChart;
-use Fuelviews\SabHeroArticle\Filament\Tables\Columns\UserAvatar;
-use Fuelviews\SabHeroArticle\Models\Category;
-use Fuelviews\SabHeroArticle\Models\Post;
-use Fuelviews\SabHeroArticle\Models\Tag;
+// use Fuelviews\SabHeroArticles\Enums\MetroType;
+use Fuelviews\SabHeroArticles\Enums\PostStatus;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Pages\CreatePost;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Pages\EditPost;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Pages\ListPosts;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Pages\ViewPost;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Widgets\ArticlePostPublishedChart;
+use Fuelviews\SabHeroArticles\Filament\Tables\Columns\UserAvatar;
+use Fuelviews\SabHeroArticles\Models\Category;
+use Fuelviews\SabHeroArticles\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Tag;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use League\Csv\Reader;
@@ -97,7 +97,7 @@ class PostResource extends Resource
             ])->defaultSort('id', 'desc')
             ->filters([
                 Tables\Filters\SelectFilter::make('user')
-                    ->relationship('user', config('sabhero-article.user.columns.name'))
+                    ->relationship('user', config('sabhero-articles.user.columns.name'))
                     ->searchable()
                     ->preload()
                     ->multiple(),
@@ -123,7 +123,7 @@ class PostResource extends Resource
                     ->beforeReplicaSaved(function (Post $replica, array $data): void {
                         $replica->title = $replica->title.' (Copy)';
                         $replica->slug = Str::slug($replica->title.' copy '.time());
-                        $replica->status = \Fuelviews\SabHeroArticle\Enums\PostStatus::PUBLISHED;
+                        $replica->status = \Fuelviews\SabHeroArticles\Enums\PostStatus::PUBLISHED;
                         $replica->published_at = null;
                         $replica->scheduled_for = null;
                     })

--- a/src/Filament/Resources/PostResource/Pages/CreatePost.php
+++ b/src/Filament/Resources/PostResource/Pages/CreatePost.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Pages;
 
 use Carbon\Carbon;
 use Filament\Resources\Pages\CreateRecord;
-use Fuelviews\SabHeroArticle\Events\ArticlePublished;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource;
-use Fuelviews\SabHeroArticle\Jobs\PostScheduleJob;
+use Fuelviews\SabHeroArticles\Events\ArticlePublished;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource;
+use Fuelviews\SabHeroArticles\Jobs\PostScheduleJob;
 
 class CreatePost extends CreateRecord
 {

--- a/src/Filament/Resources/PostResource/Pages/EditPost.php
+++ b/src/Filament/Resources/PostResource/Pages/EditPost.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
-use Fuelviews\SabHeroArticle\Enums\PostStatus;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource;
+use Fuelviews\SabHeroArticles\Enums\PostStatus;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource;
 
 class EditPost extends EditRecord
 {

--- a/src/Filament/Resources/PostResource/Pages/ListPosts.php
+++ b/src/Filament/Resources/PostResource/Pages/ListPosts.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Widgets\ArticlePostPublishedChart;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Widgets\ArticlePostPublishedChart;
 
 class ListPosts extends ListRecords
 {

--- a/src/Filament/Resources/PostResource/Pages/ViewPost.php
+++ b/src/Filament/Resources/PostResource/Pages/ViewPost.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Pages;
 
 use Filament\Actions\Action;
 use Filament\Resources\Pages\ViewRecord;
-use Fuelviews\SabHeroArticle\Events\ArticlePublished;
-use Fuelviews\SabHeroArticle\Filament\Resources\PostResource;
+use Fuelviews\SabHeroArticles\Events\ArticlePublished;
+use Fuelviews\SabHeroArticles\Filament\Resources\PostResource;
 use Illuminate\Contracts\Support\Htmlable;
 
 class ViewPost extends ViewRecord
@@ -32,7 +32,7 @@ class ViewPost extends ViewRecord
             Action::make('preview')
                 ->label('Preview')
                 ->icon('heroicon-o-eye')
-                ->url(fn () => route('sabhero-article.post.show', $this->record->slug), true)
+                ->url(fn () => route('sabhero-articles.post.show', $this->record->slug), true)
                 ->disabled(fn () => $this->record->isNotPublished()),
         ];
     }

--- a/src/Filament/Resources/PostResource/Widgets/ArticlePostPublishedChart.php
+++ b/src/Filament/Resources/PostResource/Widgets/ArticlePostPublishedChart.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\PostResource\Widgets;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\PostResource\Widgets;
 
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Post;
 
 class ArticlePostPublishedChart extends BaseWidget
 {

--- a/src/Filament/Resources/TagResource.php
+++ b/src/Filament/Resources/TagResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources;
+namespace Fuelviews\SabHeroArticles\Filament\Resources;
 
 use Filament\Forms\Form;
 use Filament\Infolists\Components\Section;
@@ -9,11 +9,11 @@ use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Fuelviews\SabHeroArticle\Filament\Resources\TagResource\Pages\EditTag;
-use Fuelviews\SabHeroArticle\Filament\Resources\TagResource\Pages\ListTags;
-use Fuelviews\SabHeroArticle\Filament\Resources\TagResource\Pages\ViewTag;
-use Fuelviews\SabHeroArticle\Filament\Resources\TagResource\RelationManagers\PostsRelationManager;
-use Fuelviews\SabHeroArticle\Models\Tag;
+use Fuelviews\SabHeroArticles\Filament\Resources\TagResource\Pages\EditTag;
+use Fuelviews\SabHeroArticles\Filament\Resources\TagResource\Pages\ListTags;
+use Fuelviews\SabHeroArticles\Filament\Resources\TagResource\Pages\ViewTag;
+use Fuelviews\SabHeroArticles\Filament\Resources\TagResource\RelationManagers\PostsRelationManager;
+use Fuelviews\SabHeroArticles\Models\Tag;
 
 class TagResource extends Resource
 {

--- a/src/Filament/Resources/TagResource/Pages/CreateTag.php
+++ b/src/Filament/Resources/TagResource/Pages/CreateTag.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\TagResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\TagResource\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\TagResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\TagResource;
 
 class CreateTag extends CreateRecord
 {

--- a/src/Filament/Resources/TagResource/Pages/EditTag.php
+++ b/src/Filament/Resources/TagResource/Pages/EditTag.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\TagResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\TagResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\TagResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\TagResource;
 
 class EditTag extends EditRecord
 {

--- a/src/Filament/Resources/TagResource/Pages/ListTags.php
+++ b/src/Filament/Resources/TagResource/Pages/ListTags.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\TagResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\TagResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
-use Fuelviews\SabHeroArticle\Filament\Resources\TagResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\TagResource;
 
 class ListTags extends ListRecords
 {

--- a/src/Filament/Resources/TagResource/Pages/ViewTag.php
+++ b/src/Filament/Resources/TagResource/Pages/ViewTag.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\TagResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\TagResource\Pages;
 
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\TagResource;
-use Fuelviews\SabHeroArticle\Models\Tag;
+use Fuelviews\SabHeroArticles\Filament\Resources\TagResource;
+use Fuelviews\SabHeroArticles\Models\Tag;
 
 class ViewTag extends ViewRecord
 {

--- a/src/Filament/Resources/TagResource/RelationManagers/PostsRelationManager.php
+++ b/src/Filament/Resources/TagResource/RelationManagers/PostsRelationManager.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\TagResource\RelationManagers;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\TagResource\RelationManagers;
 
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Support\Str;
 
 class PostsRelationManager extends RelationManager

--- a/src/Filament/Resources/UserResource.php
+++ b/src/Filament/Resources/UserResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources;
+namespace Fuelviews\SabHeroArticles\Filament\Resources;
 
 use Filament\Forms;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
@@ -14,10 +14,10 @@ use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Fuelviews\SabHeroArticle\Filament\Resources\UserResource\Pages\CreateUser;
-use Fuelviews\SabHeroArticle\Filament\Resources\UserResource\Pages\EditUser;
-use Fuelviews\SabHeroArticle\Filament\Resources\UserResource\Pages\ListUsers;
-use Fuelviews\SabHeroArticle\Filament\Resources\UserResource\Pages\ViewUser;
+use Fuelviews\SabHeroArticles\Filament\Resources\UserResource\Pages\CreateUser;
+use Fuelviews\SabHeroArticles\Filament\Resources\UserResource\Pages\EditUser;
+use Fuelviews\SabHeroArticles\Filament\Resources\UserResource\Pages\ListUsers;
+use Fuelviews\SabHeroArticles\Filament\Resources\UserResource\Pages\ViewUser;
 use Illuminate\Support\Str;
 
 class UserResource extends Resource
@@ -34,7 +34,7 @@ class UserResource extends Resource
 
     public static function getModel(): string
     {
-        return config('sabhero-article.user.model');
+        return config('sabhero-articles.user.model');
     }
 
     public static function getNavigationBadge(): ?string

--- a/src/Filament/Resources/UserResource/Pages/CreateUser.php
+++ b/src/Filament/Resources/UserResource/Pages/CreateUser.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\UserResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\UserResource\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\UserResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\UserResource;
 use Illuminate\Support\Facades\Hash;
 
 class CreateUser extends CreateRecord

--- a/src/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/src/Filament/Resources/UserResource/Pages/EditUser.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\UserResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\UserResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\UserResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\UserResource;
 
 class EditUser extends EditRecord
 {

--- a/src/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/src/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\UserResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\UserResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
-use Fuelviews\SabHeroArticle\Filament\Resources\UserResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\UserResource;
 
 class ListUsers extends ListRecords
 {

--- a/src/Filament/Resources/UserResource/Pages/ViewUser.php
+++ b/src/Filament/Resources/UserResource/Pages/ViewUser.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Resources\UserResource\Pages;
+namespace Fuelviews\SabHeroArticles\Filament\Resources\UserResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\ViewRecord;
-use Fuelviews\SabHeroArticle\Filament\Resources\UserResource;
+use Fuelviews\SabHeroArticles\Filament\Resources\UserResource;
 
 class ViewUser extends ViewRecord
 {

--- a/src/Filament/Tables/Columns/UserAvatar.php
+++ b/src/Filament/Tables/Columns/UserAvatar.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Filament\Tables\Columns;
+namespace Fuelviews\SabHeroArticles\Filament\Tables\Columns;
 
 use Filament\Tables\Columns\Column;
 
 class UserAvatar extends Column
 {
-    protected string $view = 'sabhero-article::filament.tables.columns.user-avatar';
+    protected string $view = 'sabhero-articles::filament.tables.columns.user-avatar';
 
     public function getViewData(): array
     {

--- a/src/Http/Controllers/AuthorController.php
+++ b/src/Http/Controllers/AuthorController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Http\Controllers;
+namespace Fuelviews\SabHeroArticles\Http\Controllers;
 
 class AuthorController extends Controller
 {
@@ -11,7 +11,7 @@ class AuthorController extends Controller
             ->published()
             ->paginate(10);
 
-        return view('sabhero-article::articles.authors.show', [
+        return view('sabhero-articles::articles.authors.show', [
             'posts' => $posts,
             'author' => $user,
         ]);
@@ -19,7 +19,7 @@ class AuthorController extends Controller
 
     public function allAuthors()
     {
-        $userModel = config('sabhero-article.user.model');
+        $userModel = config('sabhero-articles.user.model');
 
         $authors = $userModel::activeAuthors()
             ->withCount([
@@ -30,7 +30,7 @@ class AuthorController extends Controller
             ->orderBy('name')
             ->paginate(10);
 
-        return view('sabhero-article::articles.authors.index', [
+        return view('sabhero-articles::articles.authors.index', [
             'authors' => $authors,
         ]);
     }

--- a/src/Http/Controllers/CategoryController.php
+++ b/src/Http/Controllers/CategoryController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Http\Controllers;
+namespace Fuelviews\SabHeroArticles\Http\Controllers;
 
-use Fuelviews\SabHeroArticle\Models\Category;
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Category;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Http\Request;
 
 class CategoryController extends Controller
@@ -15,7 +15,7 @@ class CategoryController extends Controller
             ->published()
             ->paginate(10);
 
-        return view('sabhero-article::articles.categories.show', [
+        return view('sabhero-articles::articles.categories.show', [
             'posts' => $posts,
             'category' => $category,
         ]);
@@ -32,7 +32,7 @@ class CategoryController extends Controller
             ->orderBy('name')
             ->get();
 
-        return view('sabhero-article::articles.categories.index', [
+        return view('sabhero-articles::articles.categories.index', [
             'posts' => $posts,
             'categories' => $categories,
         ]);

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Http\Controllers;
+namespace Fuelviews\SabHeroArticles\Http\Controllers;
 
 abstract class Controller
 {

--- a/src/Http/Controllers/PostController.php
+++ b/src/Http/Controllers/PostController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Http\Controllers;
+namespace Fuelviews\SabHeroArticles\Http\Controllers;
 
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Http\Request;
 
 class PostController extends Controller
@@ -47,15 +47,15 @@ class PostController extends Controller
         $posts = $query->paginate(10)->withQueryString();
 
         // Get all categories, tags, and authors for the filter dropdowns
-        $categories = \Fuelviews\SabHeroArticle\Models\Category::whereHas('posts', function ($q) {
+        $categories = \Fuelviews\SabHeroArticles\Models\Category::whereHas('posts', function ($q) {
             $q->published();
         })->orderBy('name')->get();
 
-        $tags = \Fuelviews\SabHeroArticle\Models\Tag::whereHas('posts', function ($q) {
+        $tags = \Fuelviews\SabHeroArticles\Models\Tag::whereHas('posts', function ($q) {
             $q->published();
         })->orderBy('name')->get();
 
-        $userModel = config('sabhero-article.user.model');
+        $userModel = config('sabhero-articles.user.model');
         $authors = $userModel::authors()
             ->whereHas('posts', function ($q) {
                 $q->published();
@@ -63,7 +63,7 @@ class PostController extends Controller
             ->orderBy('name')
             ->get();
 
-        return view('sabhero-article::articles.index', [
+        return view('sabhero-articles::articles.index', [
             'posts' => $posts,
             'categories' => $categories,
             'tags' => $tags,
@@ -88,7 +88,7 @@ class PostController extends Controller
             ->paginate(10)
             ->withQueryString();
 
-        return view('sabhero-article::articles.search', [
+        return view('sabhero-articles::articles.search', [
             'posts' => $searchedPosts,
             'searchMessage' => 'Search result for '.$request->get('query'),
         ]);
@@ -96,7 +96,7 @@ class PostController extends Controller
 
     public function show(Post $post)
     {
-        return view('sabhero-article::articles.show', [
+        return view('sabhero-articles::articles.show', [
             'post' => $post,
         ]);
     }

--- a/src/Http/Controllers/TagController.php
+++ b/src/Http/Controllers/TagController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Http\Controllers;
+namespace Fuelviews\SabHeroArticles\Http\Controllers;
 
-use Fuelviews\SabHeroArticle\Models\Post;
-use Fuelviews\SabHeroArticle\Models\Tag;
+use Fuelviews\SabHeroArticles\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Tag;
 
 class TagController extends Controller
 {
@@ -14,7 +14,7 @@ class TagController extends Controller
             ->published()
             ->paginate(10);
 
-        return view('sabhero-article::articles.tags.show', [
+        return view('sabhero-articles::articles.tags.show', [
             'posts' => $posts,
             'tag' => $tag,
         ]);
@@ -31,7 +31,7 @@ class TagController extends Controller
             ->orderBy('name')
             ->get();
 
-        return view('sabhero-article::articles.tags.index', [
+        return view('sabhero-articles::articles.tags.index', [
             'posts' => $posts,
             'tags' => $tags,
         ]);

--- a/src/Http/Livewire/SearchAutocomplete.php
+++ b/src/Http/Livewire/SearchAutocomplete.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Http\Livewire;
+namespace Fuelviews\SabHeroArticles\Http\Livewire;
 
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Livewire\Component;
 
 class SearchAutocomplete extends Component
@@ -47,13 +47,13 @@ class SearchAutocomplete extends Component
         $this->suggestions = [];
 
         // Redirect to the post
-        return redirect()->route('sabhero-article.post.show', ['post' => $slug]);
+        return redirect()->route('sabhero-articles.post.show', ['post' => $slug]);
     }
 
     public function performSearch()
     {
         if (! empty($this->search)) {
-            return redirect()->route('sabhero-article.post.index', ['search' => $this->search]);
+            return redirect()->route('sabhero-articles.post.index', ['search' => $this->search]);
         }
     }
 
@@ -72,6 +72,6 @@ class SearchAutocomplete extends Component
 
     public function render()
     {
-        return view('sabhero-article::livewire.search-autocomplete');
+        return view('sabhero-articles::livewire.search-autocomplete');
     }
 }

--- a/src/Jobs/PostScheduleJob.php
+++ b/src/Jobs/PostScheduleJob.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Jobs;
+namespace Fuelviews\SabHeroArticles\Jobs;
 
-use Fuelviews\SabHeroArticle\Enums\PostStatus;
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Enums\PostStatus;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/src/Mails/ArticlePublished.php
+++ b/src/Mails/ArticlePublished.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Mails;
+namespace Fuelviews\SabHeroArticles\Mails;
 
-use Fuelviews\SabHeroArticle\Exceptions\CannotSendEmail;
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Exceptions\CannotSendEmail;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Models;
+namespace Fuelviews\SabHeroArticles\Models;
 
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Get;
@@ -22,7 +22,7 @@ class Category extends Model
 
     public function posts(): BelongsToMany
     {
-        return $this->belongsToMany(Post::class, config('sabhero-article.tables.prefix').'category_'.config('sabhero-article.tables.prefix').'post');
+        return $this->belongsToMany(Post::class, config('sabhero-articles.tables.prefix').'category_'.config('sabhero-articles.tables.prefix').'post');
     }
 
     public static function getForm(): array
@@ -33,12 +33,12 @@ class Category extends Model
                 ->afterStateUpdated(function (Get $get, Set $set, ?string $operation, ?string $old, ?string $state) {
                     $set('slug', Str::slug($state));
                 })
-                ->unique(config('sabhero-article.tables.prefix').'categories', 'name', null, 'id')
+                ->unique(config('sabhero-articles.tables.prefix').'categories', 'name', null, 'id')
                 ->required()
                 ->maxLength(155),
 
             TextInput::make('slug')
-                ->unique(config('sabhero-article.tables.prefix').'categories', 'slug', null, 'id')
+                ->unique(config('sabhero-articles.tables.prefix').'categories', 'slug', null, 'id')
                 ->readOnly()
                 ->maxLength(255),
         ];
@@ -56,6 +56,6 @@ class Category extends Model
 
     public function getTable(): string
     {
-        return config('sabhero-article.tables.prefix').'categories';
+        return config('sabhero-articles.tables.prefix').'categories';
     }
 }

--- a/src/Models/CategoryPost.php
+++ b/src/Models/CategoryPost.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Models;
+namespace Fuelviews\SabHeroArticles\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
@@ -19,6 +19,6 @@ class CategoryPost extends Model
 
     public function getTable(): string
     {
-        return config('sabhero-article.tables.prefix').'category_'.config('sabhero-article.tables.prefix').'post';
+        return config('sabhero-articles.tables.prefix').'category_'.config('sabhero-articles.tables.prefix').'post';
     }
 }

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Models;
+namespace Fuelviews\SabHeroArticles\Models;
 
 use Database\Factories\PageFactory;
 use Filament\Forms\Components\Section;

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Models;
+namespace Fuelviews\SabHeroArticles\Models;
 
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Fieldset;
@@ -11,7 +11,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
 use Filament\Forms\Set;
-use Fuelviews\SabHeroArticle\Enums\PostStatus;
+use Fuelviews\SabHeroArticles\Enums\PostStatus;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -58,17 +58,17 @@ class Post extends Model implements Feedable, HasMedia
 
     public function categories(): BelongsToMany
     {
-        return $this->belongsToMany(Category::class, config('sabhero-article.tables.prefix').'category_'.config('sabhero-article.tables.prefix').'post');
+        return $this->belongsToMany(Category::class, config('sabhero-articles.tables.prefix').'category_'.config('sabhero-articles.tables.prefix').'post');
     }
 
     public function tags(): BelongsToMany
     {
-        return $this->belongsToMany(Tag::class, config('sabhero-article.tables.prefix').'post_'.config('sabhero-article.tables.prefix').'tag');
+        return $this->belongsToMany(Tag::class, config('sabhero-articles.tables.prefix').'post_'.config('sabhero-articles.tables.prefix').'tag');
     }
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo(config('sabhero-article.user.model'), config('sabhero-article.user.foreign_key'));
+        return $this->belongsTo(config('sabhero-articles.user.model'), config('sabhero-articles.user.foreign_key'));
     }
 
     public function isNotPublished(): bool
@@ -109,8 +109,8 @@ class Post extends Model implements Feedable, HasMedia
     public function relatedPosts($take = 3)
     {
         return $this->whereHas('categories', function ($query) {
-            $query->whereIn(config('sabhero-article.tables.prefix').'categories.id', $this->categories->pluck('id'))
-                ->whereNotIn(config('sabhero-article.tables.prefix').'posts.id', [$this->id]);
+            $query->whereIn(config('sabhero-articles.tables.prefix').'categories.id', $this->categories->pluck('id'))
+                ->whereNotIn(config('sabhero-articles.tables.prefix').'posts.id', [$this->id]);
         })->published()->with('user')->take($take)->get();
     }
 
@@ -148,7 +148,7 @@ class Post extends Model implements Feedable, HasMedia
                                     Str::slug($state)
                                 ))
                                 ->required()
-                                ->unique(config('sabhero-article.tables.prefix').'posts', 'title', null, 'id')
+                                ->unique(config('sabhero-articles.tables.prefix').'posts', 'title', null, 'id')
                                 ->maxLength(255),
 
                             TextInput::make('slug')
@@ -222,9 +222,9 @@ class Post extends Model implements Feedable, HasMedia
                                 ->native(false),
                         ]),
 
-                    Select::make(config('sabhero-article.user.foreign_key'))
+                    Select::make(config('sabhero-articles.user.foreign_key'))
                         ->label('Author')
-                        ->relationship('user', config('sabhero-article.user.columns.name'))
+                        ->relationship('user', config('sabhero-articles.user.columns.name'))
                         ->nullable(false)
                         ->default(auth()->id()),
 
@@ -290,7 +290,7 @@ class Post extends Model implements Feedable, HasMedia
 
     public function getTable(): string
     {
-        return config('sabhero-article.tables.prefix').'posts';
+        return config('sabhero-articles.tables.prefix').'posts';
     }
 
     public static function getFeedItems()
@@ -305,9 +305,9 @@ class Post extends Model implements Feedable, HasMedia
     public function toFeedItem(): FeedItem
     {
         $siteUrl = config('app.url');
-        $articleUrl = $siteUrl.'/'.config('sabhero-article.route.prefix');
+        $articleUrl = $siteUrl.'/'.config('sabhero-articles.route.prefix');
 
-        $link = route('sabhero-article.post.show', $this);
+        $link = route('sabhero-articles.post.show', $this);
 
         return FeedItem::create()
             ->id($link)

--- a/src/Models/PostTag.php
+++ b/src/Models/PostTag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Models;
+namespace Fuelviews\SabHeroArticles\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -22,6 +22,6 @@ class PostTag extends Model
 
     public function getTable(): string
     {
-        return config('sabhero-article.tables.prefix').'post_'.config('sabhero-article.tables.prefix').'tag';
+        return config('sabhero-articles.tables.prefix').'post_'.config('sabhero-articles.tables.prefix').'tag';
     }
 }

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Models;
+namespace Fuelviews\SabHeroArticles\Models;
 
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Set;
@@ -24,7 +24,7 @@ class Tag extends Model
 
     public function posts(): BelongsToMany
     {
-        return $this->belongsToMany(Post::class, config('sabhero-article.tables.prefix').'post_'.config('sabhero-article.tables.prefix').'tag');
+        return $this->belongsToMany(Post::class, config('sabhero-articles.tables.prefix').'post_'.config('sabhero-articles.tables.prefix').'tag');
     }
 
     public static function getForm(): array
@@ -35,12 +35,12 @@ class Tag extends Model
                     'slug',
                     Str::slug($state)
                 ))
-                ->unique(config('sabhero-article.tables.prefix').'tags', 'name', null, 'id')
+                ->unique(config('sabhero-articles.tables.prefix').'tags', 'name', null, 'id')
                 ->required()
                 ->maxLength(50),
 
             TextInput::make('slug')
-                ->unique(config('sabhero-article.tables.prefix').'tags', 'slug', null, 'id')
+                ->unique(config('sabhero-articles.tables.prefix').'tags', 'slug', null, 'id')
                 ->readOnly()
                 ->maxLength(155),
         ];
@@ -58,6 +58,6 @@ class Tag extends Model
 
     public function getTable(): string
     {
-        return config('sabhero-article.tables.prefix').'tags';
+        return config('sabhero-articles.tables.prefix').'tags';
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Models;
+namespace Fuelviews\SabHeroArticles\Models;
 
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasAvatar;
 use Filament\Panel;
-use Fuelviews\SabHeroArticle\Traits\HasArticle;
+use Fuelviews\SabHeroArticles\Traits\HasArticle;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -64,7 +64,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasMedia
      */
     public function posts(): HasMany
     {
-        return $this->hasMany(Post::class, config('sabhero-article.user.foreign_key'));
+        return $this->hasMany(Post::class, config('sabhero-articles.user.foreign_key'));
     }
 
     /**
@@ -140,7 +140,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasMedia
      */
     public function name(): string
     {
-        return $this->{config('sabhero-article.user.columns.name', 'name')};
+        return $this->{config('sabhero-articles.user.columns.name', 'name')};
     }
 
     /**
@@ -153,7 +153,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasMedia
 
     public function canAccessPanel(Panel $panel): bool
     {
-        $allowedDomains = config('sabhero-article.user.allowed_domains', []);
+        $allowedDomains = config('sabhero-articles.user.allowed_domains', []);
 
         foreach ($allowedDomains as $domain) {
             if (str_ends_with($this->email, $domain)) {

--- a/src/Renderers/GlideImageRenderer.php
+++ b/src/Renderers/GlideImageRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Renderers;
+namespace Fuelviews\SabHeroArticles\Renderers;
 
 use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
 use League\CommonMark\Node\Inline\Newline;
@@ -19,9 +19,9 @@ final class GlideImageRenderer implements NodeRendererInterface, XmlNodeRenderer
 {
     /** @psalm-readonly-allow-private-mutation */
     private ConfigurationInterface $config;
-    
+
     private array $glideConfig;
-    
+
     public function __construct(array $glideConfig = [])
     {
         $this->glideConfig = array_merge([
@@ -102,11 +102,11 @@ final class GlideImageRenderer implements NodeRendererInterface, XmlNodeRenderer
 
         // Normalize the URL once for all srcset generation
         $normalizedUrl = $this->normalizeImagePath($url);
-        
+
         // Use Laravel Glide's built-in srcset generation
         $maxWidth = max($this->glideConfig['srcset_widths']);
         $attributes = glide()->src($normalizedUrl, $maxWidth, sizes: $this->glideConfig['sizes']);
-        
+
         return $attributes->get('srcset');
     }
 
@@ -166,7 +166,7 @@ final class GlideImageRenderer implements NodeRendererInterface, XmlNodeRenderer
 
         return $altText;
     }
-    
+
     /**
      * Normalize image path for Glide processing
      * Convert /storage/images/ to images/ since Glide expects relative paths
@@ -175,11 +175,11 @@ final class GlideImageRenderer implements NodeRendererInterface, XmlNodeRenderer
     {
         // Remove the /storage/ prefix if present
         $path = ltrim($url, '/');
-        
+
         if (str_starts_with($path, 'storage/')) {
             $path = substr($path, 8); // Remove 'storage/' prefix
         }
-        
+
         return $path;
     }
 }

--- a/src/Renderers/TableOfContentsRenderer.php
+++ b/src/Renderers/TableOfContentsRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Renderers;
+namespace Fuelviews\SabHeroArticles\Renderers;
 
 use InvalidArgumentException;
 use League\CommonMark\Extension\TableOfContents\Node\TableOfContents;

--- a/src/SabHeroArticles.php
+++ b/src/SabHeroArticles.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle;
+namespace Fuelviews\SabHeroArticles;
 
 use Filament\Contracts\Plugin;
 use Filament\Navigation\NavigationItem;
 use Filament\Panel;
 use Filament\Support\Colors\Color;
 
-class SabHeroArticle implements Plugin
+class SabHeroArticles implements Plugin
 {
     public static function make(): static
     {
@@ -16,7 +16,7 @@ class SabHeroArticle implements Plugin
 
     public function getId(): string
     {
-        return 'sabhero-article';
+        return 'sabhero-articles';
     }
 
     public function register(Panel $panel): void
@@ -35,9 +35,9 @@ class SabHeroArticle implements Plugin
 
         $panel->navigationItems([
             NavigationItem::make('CRM')
-                ->label(config('sabhero-article.crm.name'))
+                ->label(config('sabhero-articles.crm.name'))
                 ->url(function () {
-                    $link = config('sabhero-article.crm.link');
+                    $link = config('sabhero-articles.crm.link');
                     if (! str_starts_with($link, 'http://') && ! str_starts_with($link, 'https://')) {
                         $link = 'https://'.$link;
                     }

--- a/src/SabHeroArticlesEventServiceProvider.php
+++ b/src/SabHeroArticlesEventServiceProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle;
+namespace Fuelviews\SabHeroArticles;
 
-use Fuelviews\SabHeroArticle\Events\ArticlePublished;
+use Fuelviews\SabHeroArticles\Events\ArticlePublished;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
-class SabHeroArticleEventServiceProvider extends ServiceProvider
+class SabHeroArticlesEventServiceProvider extends ServiceProvider
 {
     protected $listen = [
         ArticlePublished::class => [

--- a/src/SabHeroArticlesServiceProvider.php
+++ b/src/SabHeroArticlesServiceProvider.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle;
+namespace Fuelviews\SabHeroArticles;
 
-use Fuelviews\SabHeroArticle\Components\Breadcrumb;
-use Fuelviews\SabHeroArticle\Components\Card;
-use Fuelviews\SabHeroArticle\Components\FeatureCard;
-use Fuelviews\SabHeroArticle\Components\HeaderCategory;
-use Fuelviews\SabHeroArticle\Components\Layout;
-use Fuelviews\SabHeroArticle\Components\Markdown;
-use Fuelviews\SabHeroArticle\Components\RecentPost;
-use Fuelviews\SabHeroArticle\Http\Livewire\SearchAutocomplete;
-use Fuelviews\SabHeroArticle\Models\Page;
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Components\Breadcrumb;
+use Fuelviews\SabHeroArticles\Components\Card;
+use Fuelviews\SabHeroArticles\Components\FeatureCard;
+use Fuelviews\SabHeroArticles\Components\HeaderCategory;
+use Fuelviews\SabHeroArticles\Components\Layout;
+use Fuelviews\SabHeroArticles\Components\Markdown;
+use Fuelviews\SabHeroArticles\Components\RecentPost;
+use Fuelviews\SabHeroArticles\Http\Livewire\SearchAutocomplete;
+use Fuelviews\SabHeroArticles\Models\Page;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
@@ -20,13 +20,13 @@ use Spatie\Feed\FeedServiceProvider;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
-class SabHeroArticleServiceProvider extends PackageServiceProvider
+class SabHeroArticlesServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
     {
-        $package->name('sabhero-article')
+        $package->name('sabhero-articles')
             ->hasConfigFile([
-                'sabhero-article',
+                'sabhero-articles',
                 'feed',
             ])
             ->hasMigrations([
@@ -40,7 +40,7 @@ class SabHeroArticleServiceProvider extends PackageServiceProvider
             ])
 
             ->hasViewComponents(
-                'sabhero-article',
+                'sabhero-articles',
                 Layout::class,
                 RecentPost::class,
                 HeaderCategory::class,
@@ -49,7 +49,7 @@ class SabHeroArticleServiceProvider extends PackageServiceProvider
                 Markdown::class,
                 Breadcrumb::class,
             )
-            ->hasViews('sabhero-article')
+            ->hasViews('sabhero-articles')
             ->hasRoutes([
                 'web',
                 'breadcrumbs',
@@ -59,7 +59,7 @@ class SabHeroArticleServiceProvider extends PackageServiceProvider
 
     public function register()
     {
-        Paginator::defaultView('sabhero-article::pagination.tailwind');
+        Paginator::defaultView('sabhero-articles::pagination.tailwind');
 
         Route::bind('post', function ($value) {
             return Post::where('slug', $value)
@@ -69,7 +69,7 @@ class SabHeroArticleServiceProvider extends PackageServiceProvider
         });
 
         Route::bind('user', function ($value) {
-            $userModel = config('sabhero-article.user.model');
+            $userModel = config('sabhero-articles.user.model');
 
             return $userModel::where('slug', $value)->firstOrFail();
         });
@@ -79,7 +79,7 @@ class SabHeroArticleServiceProvider extends PackageServiceProvider
         ], static function ($view) {
             if (request()->route() &&
                 in_array(request()->route()->getName(), [
-                    'sabhero-article.post.show',
+                    'sabhero-articles.post.show',
                 ])) {
                 $seoPost = request()->route('post');
 
@@ -89,7 +89,7 @@ class SabHeroArticleServiceProvider extends PackageServiceProvider
             }
         });
 
-        $this->app->register(SabHeroArticleEventServiceProvider::class);
+        $this->app->register(SabHeroArticlesEventServiceProvider::class);
 
         return parent::register();
     }
@@ -110,14 +110,14 @@ class SabHeroArticleServiceProvider extends PackageServiceProvider
     {
         $this->publishes([
             __DIR__.'/../database/seeders/PageTableSeeder.php' => database_path('seeders/PageTableSeeder.php'),
-        ], 'sabhero-article-seeders');
+        ], 'sabhero-articles-seeders');
 
         // Register FeedServiceProvider after views are registered
         $this->app->register(FeedServiceProvider::class);
 
         // Register Livewire components if Livewire is available and not in testing
         if (class_exists(\Livewire\Livewire::class) && ! $this->app->environment('testing')) {
-            Livewire::component('sabhero-article::search-autocomplete', SearchAutocomplete::class);
+            Livewire::component('sabhero-articles::search-autocomplete', SearchAutocomplete::class);
         }
     }
 

--- a/src/Traits/HasArticle.php
+++ b/src/Traits/HasArticle.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Traits;
+namespace Fuelviews\SabHeroArticles\Traits;
 
-use Fuelviews\SabHeroArticle\Models\Post;
+use Fuelviews\SabHeroArticles\Models\Post;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
@@ -44,7 +44,7 @@ trait HasArticle
 
     public function posts(): HasMany
     {
-        return $this->hasMany(Post::class, config('sabhero-article.user.foreign_key'));
+        return $this->hasMany(Post::class, config('sabhero-articles.user.foreign_key'));
     }
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,5 @@
 <?php
 
-use Fuelviews\SabHeroArticle\Tests\TestCase;
+use Fuelviews\SabHeroArticles\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Fuelviews\SabHeroArticle\Tests;
+namespace Fuelviews\SabHeroArticles\Tests;
 
-use Fuelviews\SabHeroArticle\SabHeroArticleServiceProvider;
+use Fuelviews\SabHeroArticles\SabHeroArticlesServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\Feed\FeedServiceProvider;
@@ -14,14 +14,14 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName): string => 'Fuelviews\\SabHeroArticle\\Database\\Factories\\'.class_basename($modelName).'Factory'
+            fn (string $modelName): string => 'Fuelviews\\SabHeroArticles\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
     }
 
     protected function getPackageProviders($app)
     {
         return [
-            SabHeroArticleServiceProvider::class,
+            SabHeroArticlesServiceProvider::class,
             FeedServiceProvider::class,
         ];
     }


### PR DESCRIPTION
Renames the package from "sabhero-article" to "sabhero-articles" to ensure consistent naming and branding across the project. The changes include updates to namespaces, classes, configuration files, routes, views, and documentation to reflect the new pluralized package name.

**Changes:**
1. Updated all occurrences of "sabhero-article" to "sabhero-articles" in the `CHANGELOG.md`, `README.md`, and `composer.json` files.
2. Modified namespaces, class names, and configuration keys in PHP files to use "SabHeroArticles" instead of "SabHeroArticle".
3. Adjusted Blade component tags and route names in view files to align with the new package name.
4. Updated database migration and seeder files to reflect the pluralized naming convention.